### PR TITLE
load not auto-loadable class question_bank - Moodle 4.1

### DIFF
--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -35,6 +35,7 @@ use question_bank;
 defined('MOODLE_INTERNAL') || die;
 
 require_once(__DIR__ . '/../../../../../behat/classes/util.php');
+require_once(__DIR__ . '/../../../../../../question/engine/bank.php');
 
 /**
  * The capabilities of the plugin, in this case there is one toolbar button and one menu item.


### PR DESCRIPTION
Had this error when trying to add either a purpose or category in the data registry (`admin/tool/dataprivacy/dataregistry.php`)

Loading the class file fixes this issue.

Discovered with @phager-at